### PR TITLE
fix flickering with cmdheight=0

### DIFF
--- a/lua/fold-cycle/utils.lua
+++ b/lua/fold-cycle/utils.lua
@@ -41,6 +41,7 @@ M.softwrap_movement_fix = function(movement)
 	else
 		cmd("normal! " .. movement)
 	end
+	cmd("redraw")
 end
 
 return M


### PR DESCRIPTION
See https://asciinema.org/a/548438

Notice at the last line how is disappearing when pressing j/k. I restore it with a redraw (with <C-l>), running the command at the end of the mapping is good enough.