### PR TITLE
fix: remove t_vb usage

### DIFF
--- a/lua/fold-cycle/fold-cycle.lua
+++ b/lua/fold-cycle/fold-cycle.lua
@@ -68,14 +68,11 @@ local function find_next_fold(line)
 
 	cmd(tostring(line))
 
-	local saved_t_vb = api.nvim_get_option("t_vb")
 	local saved_visualbell = api.nvim_get_option("visualbell")
 	api.nvim_set_option("visualbell", true)
-	api.nvim_set_option("t_vb", "")
 
 	cmd("normal! zj")
 
-	api.nvim_set_option("t_vb", saved_t_vb)
 	api.nvim_set_option("visualbell", saved_visualbell)
 
 	local next_fold_line = fn.line(".")


### PR DESCRIPTION
Neovim doesn't use t_vb, and it started throwing this error today:

```
E5108: Error executing lua: ...im/plugins/fold-cycle.nvim/lua/fold-cycle/fold-cycle.lua:71: Invalid option name: 't_vb'
stack traceback:
        [C]: in function 'nvim_get_option'
        ...im/plugins/fold-cycle.nvim/lua/fold-cycle/fold-cycle.lua:71: in function 'find_next_fold'
        ...im/plugins/fold-cycle.nvim/lua/fold-cycle/fold-cycle.lua:123: in function 'find_max_closed_fold_level'
        ...im/plugins/fold-cycle.nvim/lua/fold-cycle/fold-cycle.lua:178: in function 'init'
        ...im/plugins/fold-cycle.nvim/lua/fold-cycle/fold-cycle.lua:229: in function 'open'
        /home/x/.config/nvim/lua/modules/workflow/folds.lua:233: in function </home/x/.config/nvim/lua/modules/workflow/folds.lua:232>
```