### PR TITLE
Take arguments in open/close

### DIFF
--- a/lua/fold-cycle/fold-cycle.lua
+++ b/lua/fold-cycle/fold-cycle.lua
@@ -22,7 +22,7 @@ local init_cfg = {}
 
 -- open a branch
 local function open_branch()
-  cmd(init_cfg["branch_start"] .. "," .. init_cfg["branch_end"] .. " foldopen!")
+  cmd(init_cfg.branch_start .. "," .. init_cfg.branch_end .. " foldopen!")
 end
 
 -- determines if the fold at `line` is open
@@ -111,11 +111,11 @@ end
 
 -- searches the branch's open folds to find their max fold level
 local function find_max_open_fold_level()
-  local max_fold_level = init_cfg["fold_level"]
-  local line = init_cfg["branch_start"]
+  local max_fold_level = init_cfg.fold_level
+  local line = init_cfg.branch_start
 
   -- go through the whole branch from beginning to end
-  while line ~= nil and line < init_cfg["branch_end"] do
+  while line ~= nil and line < init_cfg.branch_end do
     -- check if the current line has fold level higher than max_fold_level and isn't folded
     if (fn.foldlevel(line) > max_fold_level) and not is_fold_closed(line) then
       max_fold_level = fn.foldlevel(line)
@@ -129,11 +129,11 @@ end
 
 -- searches the branch's closed folds to find their max fold level
 local function find_max_closed_fold_level()
-  local line = init_cfg["branch_start"]
-  local max_fold_level = init_cfg["fold_level"]
+  local line = init_cfg.branch_start
+  local max_fold_level = init_cfg.fold_level
 
   -- go through the whole branch from beginning to end
-  while line ~= nil and line < init_cfg["branch_end"] do
+  while line ~= nil and line < init_cfg.branch_end do
     if (fn.foldlevel(line) > max_fold_level) and is_fold_closed(line) then
       max_fold_level = fn.foldlevel(line)
     end
@@ -147,10 +147,10 @@ end
 -- close all folds of a certain fold level in the branch
 local function close_branch(level)
   -- start looking for branches at top of branch
-  local line = init_cfg["branch_start"]
+  local line = init_cfg.branch_start
 
   -- go through all the branch
-  while line ~= nil and line <= init_cfg["branch_end"] do
+  while line ~= nil and line <= init_cfg.branch_end do
     -- if foldlevel fo current line is level currently being closed and current line isn't folded
     if (fn.foldlevel(line) == level) and not is_fold_closed(line) then
       -- then fold it
@@ -164,8 +164,8 @@ end
 
 -- recursively closes all folds in branch
 local function close_all_folds_in_branch()
-  local level = init_cfg["max_open_fold_level"]
-  while not is_fold_closed(init_cfg["current_line"]) do
+  local level = init_cfg.max_open_fold_level
+  while not is_fold_closed(init_cfg.current_line) do
     close_branch(level)
     level = level - 1
   end
@@ -175,28 +175,28 @@ local function init()
   -- line number of current line
   local init_success = false
 
-  init_cfg["current_line"] = api.nvim_win_get_cursor(0)[1]
+  init_cfg.current_line = api.nvim_win_get_cursor(0)[1]
   -- fold level
-  init_cfg["fold_level"] = fn.foldlevel(init_cfg["current_line"])
+  init_cfg.fold_level = fn.foldlevel(init_cfg.current_line)
 
   -- if current line cannot be folded, exit
-  if init_cfg["fold_level"] > 0 then
+  if init_cfg.fold_level > 0 then
     -- true if the current line is folded
-    init_cfg["current_line_folded"] = is_fold_closed(init_cfg["current_line"])
+    init_cfg.current_line_folded = is_fold_closed(init_cfg.current_line)
 
     -- beginning of branch/fold of which the current line is a part
-    init_cfg["branch_start"] = find_branch(init_cfg["current_line"], "start")
+    init_cfg.branch_start = find_branch(init_cfg.current_line, "start")
 
     -- end of branch/fold of which the current line is a part
-    init_cfg["branch_end"] = find_branch(init_cfg["current_line"], "end")
+    init_cfg.branch_end = find_branch(init_cfg.current_line, "end")
 
     -- if branch_end or branch_start not a fold
-    if init_cfg["branch_end"] ~= nil and init_cfg["branch_start"] ~= nil then
+    if init_cfg.branch_end ~= nil and init_cfg.branch_start ~= nil then
       -- max fold level of closed folds in branch
-      init_cfg["max_closed_fold_level"] = find_max_closed_fold_level()
+      init_cfg.max_closed_fold_level = find_max_closed_fold_level()
 
       -- max fold level of open folds in branch
-      init_cfg["max_open_fold_level"] = find_max_open_fold_level()
+      init_cfg.max_open_fold_level = find_max_open_fold_level()
 
       -- init was successful
       init_success = true
@@ -301,7 +301,7 @@ M.toggle_all = function()
     return
   end
 
-  if init_cfg["current_line_folded"] then
+  if init_cfg.current_line_folded then
     open_branch()
   else
     close_all_folds_in_branch()
@@ -315,16 +315,16 @@ M.open = function()
 
   -- if current line is folded
   if init_success then
-    if init_cfg["current_line_folded"] then
+    if init_cfg.current_line_folded then
       cmd("foldopen")
       -- if branch is completely unfolded
-    elseif init_cfg["max_closed_fold_level"] == init_cfg["fold_level"] and config.close_if_max_opened then
+    elseif init_cfg.max_closed_fold_level == init_cfg.fold_level and config.close_if_max_opened then
       close_all_folds_in_branch()
       -- if current line is unfolded but branch can still be further unfolded
     else
-      local line = init_cfg["branch_start"]
-      while line ~= nil and line < init_cfg["branch_end"] do
-        if fn.foldlevel(line) <= init_cfg["max_closed_fold_level"] and is_fold_closed(line) then
+      local line = init_cfg.branch_start
+      while line ~= nil and line < init_cfg.branch_end do
+        if fn.foldlevel(line) <= init_cfg.max_closed_fold_level and is_fold_closed(line) then
           cmd(line .. "foldopen")
         end
 
@@ -343,13 +343,13 @@ M.close = function()
 
   -- if current line is folded
   if init_success then
-    if init_cfg["current_line_folded"] and config.open_if_max_closed then
+    if init_cfg.current_line_folded and config.open_if_max_closed then
       open_branch()
       -- if there are no open folds in branch with a fold level different from current line
-    elseif init_cfg["max_open_fold_level"] == init_cfg["fold_level"] then
+    elseif init_cfg.max_open_fold_level == init_cfg.fold_level then
       cmd("foldclose")
     else
-      close_branch(init_cfg["max_open_fold_level"])
+      close_branch(init_cfg.max_open_fold_level)
     end
   else
     M.global_close()

--- a/lua/fold-cycle/fold-cycle.lua
+++ b/lua/fold-cycle/fold-cycle.lua
@@ -208,7 +208,7 @@ end
 local M = {}
 
 -- global open folds
-M.global_open = function()
+M.global_open = function(close_if_max_opened)
   local line = 1
   local last_line = vim.fn.line("$")
   local opened_any_fold = false
@@ -232,13 +232,17 @@ M.global_open = function()
     end
   end
 
-  if not opened_any_fold and config.close_if_max_opened then
+  if close_if_max_opened == nil then
+    close_if_max_opened = config.close_if_max_opened
+  end
+
+  if not opened_any_fold and close_if_max_opened then
     close_all_folds_cmd()
   end
 end
 
 -- global close folds
-M.global_close = function()
+M.global_close = function(open_if_max_closed)
   local last_line = vim.fn.line("$")
   local closed_any_fold = false
 
@@ -265,7 +269,11 @@ M.global_close = function()
     end
   end
 
-  if not closed_any_fold and config.open_if_max_closed then
+  if open_if_max_closed == nil then
+    open_if_max_closed = config.open_if_max_closed
+  end
+
+  if not closed_any_fold and open_if_max_closed then
     open_all_folds_cmd()
   end
 end
@@ -309,7 +317,11 @@ M.toggle_all = function()
 end
 
 -- open one level of folds in branch
-M.open = function()
+M.open = function(close_if_max_opened)
+  if close_if_max_opened == nil then
+    close_if_max_opened = config.close_if_max_opened
+  end
+
   -- if no fold at current_line, return
   local init_success = init()
 
@@ -318,7 +330,7 @@ M.open = function()
     if init_cfg.current_line_folded then
       cmd("foldopen")
       -- if branch is completely unfolded
-    elseif init_cfg.max_closed_fold_level == init_cfg.fold_level and config.close_if_max_opened then
+    elseif init_cfg.max_closed_fold_level == init_cfg.fold_level and close_if_max_opened then
       close_all_folds_in_branch()
       -- if current line is unfolded but branch can still be further unfolded
     else
@@ -332,18 +344,22 @@ M.open = function()
       end
     end
   else
-    M.global_open()
+    M.global_open(close_if_max_opened)
   end
 end
 
 -- close one level of folds in branch
-M.close = function()
+M.close = function(open_if_max_closed)
+  if open_if_max_closed == nil then
+    open_if_max_closed = config.open_if_max_closed
+  end
+
   -- if no fold at current_line, return
   local init_success = init()
 
   -- if current line is folded
   if init_success then
-    if init_cfg.current_line_folded and config.open_if_max_closed then
+    if init_cfg.current_line_folded and open_if_max_closed then
       open_branch()
       -- if there are no open folds in branch with a fold level different from current line
     elseif init_cfg.max_open_fold_level == init_cfg.fold_level then
@@ -352,7 +368,7 @@ M.close = function()
       close_branch(init_cfg.max_open_fold_level)
     end
   else
-    M.global_close()
+    M.global_close(open_if_max_closed)
   end
 end
 

--- a/lua/fold-cycle/fold-cycle.lua
+++ b/lua/fold-cycle/fold-cycle.lua
@@ -207,13 +207,6 @@ end
 
 local M = {}
 
-if M.should_close_all_folds == nil then
-  M.should_close_all_folds = false
-end
-if M.should_open_all_folds == nil then
-  M.should_open_all_folds = false
-end
-
 -- global open folds
 M.global_open = function()
   local line = 1
@@ -239,13 +232,8 @@ M.global_open = function()
     end
   end
 
-  if not opened_any_fold then
-    M.should_close_all_folds = true
-  end
-
-  if M.should_close_all_folds then
+  if not opened_any_fold and config.close_if_max_opened then
     close_all_folds_cmd()
-    M.should_close_all_folds = false
   end
 end
 
@@ -277,12 +265,8 @@ M.global_close = function()
     end
   end
 
-  if not closed_any_fold then
-    M.should_open_all_folds = true
-  end
-  if M.should_open_all_folds then
+  if not closed_any_fold and config.open_if_max_closed then
     open_all_folds_cmd()
-    M.should_open_all_folds = false
   end
 end
 

--- a/lua/fold-cycle/init.lua
+++ b/lua/fold-cycle/init.lua
@@ -14,8 +14,8 @@ M.setup = function(opts)
   config.update(opts)
 
   -- add fix for softwrap movement over folds
-  if config["softwrap_movement_fix"] == true then
-    M["softwrap_movement_fix"] = utils.softwrap_movement_fix
+  if config.softwrap_movement_fix == true then
+    M.softwrap_movement_fix = utils.softwrap_movement_fix
 
     keymap.set({ "n", "v" }, "j", function()
       return vim.v.count == 0 and [[<cmd>lua require('fold-cycle').softwrap_movement_fix('j')<cr>]] or "j"


### PR DESCRIPTION
Depends on #8, let me know and I can rebase.

There are cases where I want each of `close_if_max_opened` and `open_if_max_closed` to be active, and other cases where I don't. This results in a configuration that looks something like this:

```lua
{
  'jghauser/fold-cycle.nvim',
  keys = {
    { '<Tab>', function() require('fold-cycle').open() end, desc = 'Cycle folds forward' },
    { '<S-Tab>', function() require('fold-cycle').close() end, desc = 'Cycle folds backward' },
    {
      '<CR>',
      function()
        local config = require('fold-cycle.config')
        local close_if_max_opened = config.close_if_max_opened
        config.update { close_if_max_opened = false }
        require('fold-cycle').open()
        config.update { close_if_max_opened = close_if_max_opened }
      end,
      desc = 'Open folds recursively',
    },
    {
      '<BS>',
      function()
        local config = require('fold-cycle.config')
        local open_if_max_closed = config.open_if_max_closed
        config.update { open_if_max_closed = false }
        require('fold-cycle').close()
        config.update { open_if_max_closed = open_if_max_closed }
      end,
      desc = 'Close folds recursively',
    },
  },
  config = true,
}
```

Which is less than ideal. This PR addresses that by providing arguments to the fold opening/closing functions which override the underlying config values.

Typically an `opts` table is used for something like this, but I decided against that since only one of `close_if_max_opened` or `open_if_max_closed` is relevant to any of the respective functions.